### PR TITLE
docs: add GitLab Pages ao bloco Blog/Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Salvar uma grana enquanto estamos criando ambiente para estudar. Simples.
 ### Blog/Docs
 
 - [ ] [Github Pages](https://pages.github.com/) - Free
+- [ ] [Gitlab Pages](https://docs.gitlab.com/ee/user/project/pages/) - Free
 
 ### Observabilidade
 


### PR DESCRIPTION
Sugestão do GitLab Pages como repositório para publicação de sites estáticos direto do repositório GitLab